### PR TITLE
Support headless Pygame mode with env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ Il file `src/main.py` contiene un loop Pygame minimale da cui iniziare lo svilup
    python src/main.py
    ```
 
+### Modalità headless
+In ambienti senza display (ad esempio integrazione continua), il gioco può
+essere eseguito in modalità *headless* utilizzando il driver video ``dummy``.
+Per forzare la modalità headless è possibile impostare la variabile
+``PYGAME_HEADLESS`` a ``1`` prima di avviare lo script:
+
+```bash
+PYGAME_HEADLESS=1 python src/main.py
+```
+
+Impostando ``PYGAME_HEADLESS`` a ``0`` si disabilita la modalità headless,
+forzando l'uso del driver video standard. Se la variabile non è definita, la
+modalità headless viene attivata automaticamente solo quando non è rilevato
+alcun display.
+
 ## Controlli da tastiera
 - **Freccia su** – accelera
 - **Freccia giù** – frena o retromarcia

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pygame
 from game.physics import CarPhysics
 from game.camera import Camera
@@ -7,7 +8,19 @@ from game.track_loader import load_random_track
 
 
 def init_pygame():
-    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    """Initialize Pygame, supporting headless environments.
+
+    The SDL ``dummy`` video driver is enabled automatically when no display is
+    detected (e.g. in CI) or when the ``PYGAME_HEADLESS`` environment variable is
+    set to ``1``.  Setting ``PYGAME_HEADLESS`` to ``0`` forces the normal video
+    driver even if no display is present.
+    """
+
+    headless_env = os.getenv("PYGAME_HEADLESS")
+    if headless_env == "1" or (
+        headless_env is None and os.environ.get("DISPLAY") is None and sys.platform != "win32"
+    ):
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
     pygame.init()
     return pygame.display.set_mode((800, 600))
 


### PR DESCRIPTION
## Summary
- Add `PYGAME_HEADLESS` env toggle and auto-detection for `SDL_VIDEODRIVER`
- Document how to enable or disable headless mode in README

## Testing
- `python -m py_compile src/main.py`
- `timeout 3 python src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68acdae27770832ca353a94f17919dc5