### PR TITLE
Use clock.tick for delta time

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,7 @@ class Game:
                 if event.type == pygame.QUIT:
                     self.running = False
             throttle, brake, steering = get_input()
-            dt = self.clock.get_time() / 1000.0
+            dt = self.clock.tick(60) / 1000.0
             self.physics.update(throttle, brake, steering, dt)
             self.camera.update(self.physics.position)
             self.screen.fill((0, 0, 0))
@@ -35,7 +35,6 @@ class Game:
             car_rect.center = (400, 300)
             pygame.draw.rect(self.screen, (255, 0, 0), car_rect)
             pygame.display.flip()
-            self.clock.tick(60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `clock.tick(60)` to compute delta time directly in game loop
- remove redundant `clock.tick` call and clean up file ending

## Testing
- `pytest -q`
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68acdb98a21c832c98787da517f9f4d4