### PR TITLE
Add escape key handling and analog input support

### DIFF
--- a/src/game/input_handler.py
+++ b/src/game/input_handler.py
@@ -2,12 +2,35 @@ import pygame
 
 
 def get_input():
+    """Read player input.
+
+    Returns throttle, brake and steering values in the range ``[0, 1]`` for
+    throttle/brake and ``[-1, 1]`` for steering.  Keyboard input is mapped to
+    digital values (0 or 1) while an attached joystick provides analogue
+    intensities.
+    """
+
     keys = pygame.key.get_pressed()
-    throttle = keys[pygame.K_w] or keys[pygame.K_UP]
-    brake = keys[pygame.K_s] or keys[pygame.K_DOWN]
-    steering = 0
+
+    throttle = 1.0 if keys[pygame.K_w] or keys[pygame.K_UP] else 0.0
+    brake = 1.0 if keys[pygame.K_s] or keys[pygame.K_DOWN] else 0.0
+    steering = 0.0
     if keys[pygame.K_a] or keys[pygame.K_LEFT]:
-        steering -= 1
+        steering -= 1.0
     if keys[pygame.K_d] or keys[pygame.K_RIGHT]:
-        steering += 1
+        steering += 1.0
+
+    # Joystick support (first joystick only)
+    if pygame.joystick.get_count() > 0:
+        joystick = pygame.joystick.Joystick(0)
+        if not joystick.get_init():
+            joystick.init()
+        # Axis values are in the range [-1, 1]
+        axis_x = joystick.get_axis(0)
+        axis_y = joystick.get_axis(1)
+
+        steering = axis_x
+        throttle = max(0.0, -axis_y)
+        brake = max(0.0, axis_y)
+
     return float(throttle), float(brake), float(steering)

--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,8 @@ class Game:
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.running = False
+                elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    self.running = False
             throttle, brake, steering = get_input()
             dt = self.clock.tick(60) / 1000.0
             self.physics.update(throttle, brake, steering, dt)


### PR DESCRIPTION
## Summary
- Allow exiting game loop with Escape key
- Support analog throttle, brake, steering, and basic joystick input

## Testing
- `python -m py_compile src/main.py src/game/input_handler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ace52d92cc832cb56f58b9690e8dbd