### PR TITLE
Draw car using camera-relative coordinates

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -47,7 +47,11 @@ class Game:
             self.camera.update(self.physics.position)
             self.screen.fill((0, 0, 0))
             car_rect = pygame.Rect(0, 0, 40, 20)
-            car_rect.center = (400, 300)
+            draw_pos = (
+                int(self.physics.position.x - self.camera.position[0]),
+                int(self.physics.position.y - self.camera.position[1]),
+            )
+            car_rect.center = draw_pos
             pygame.draw.rect(self.screen, (255, 0, 0), car_rect)
             pygame.display.flip()
 


### PR DESCRIPTION
## Summary
- render car based on camera-relative position rather than a fixed point

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ace5cad250832c8092b3093f36330c