### PR TITLE
Playable browser pseudo-3D rally (Canvas)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,44 @@
-# 2dRally
+# 2dRally (Browser Edition)
 
-## Obiettivo del progetto
-2dRally mira a diventare un semplice gioco di corse in 2D, ispirato ai rally classici.
-L'obiettivo è offrire un esempio didattico di sviluppo di videogiochi in Python
-utilizzando la libreria Pygame.
+Gioco rally arcade pseudo-3D giocabile direttamente da browser con `Canvas 2D`.
 
-## Stato attuale
-Il progetto è nelle fasi iniziali e non include ancora il gameplay completo.
-Il file `src/main.py` contiene un loop Pygame minimale da cui iniziare lo sviluppo.
+## Caratteristiche implementate
+- Visuale terza persona con auto del giocatore vista da dietro, in basso allo schermo.
+- Strada pseudo-3D a segmenti con prospettiva e curve cumulative.
+- Controlli arcade (`WASD` o frecce) con accelerazione, frenata e sterzo.
+- Penalità fuori strada.
+- Ostacoli + traffico semplice con collisioni.
+- Start screen, HUD (velocità/distanza), game over e restart.
 
-## Dipendenze
-- Python 3.x
-- [Pygame](https://www.pygame.org/) – installabile con:
-  ```bash
-  pip install pygame
-  ```
+## Struttura
+- `index.html`
+- `style.css`
+- `src/main.js`
+- `src/game.js`
+- `src/render.js`
+- `src/input.js`
+- `src/track.js`
+- `src/entities.js`
+- `src/ui.js`
 
-## Avvio del gioco
-1. Installare le dipendenze indicate.
-2. Avviare l'applicazione eseguendo:
-   ```bash
-   python src/main.py
-   ```
+## Avvio rapido
+Nessun backend richiesto.
 
-### Modalità headless
-In ambienti senza display (ad esempio integrazione continua), il gioco può
-essere eseguito in modalità *headless* utilizzando il driver video ``dummy``.
-Per forzare la modalità headless è possibile impostare la variabile
-``PYGAME_HEADLESS`` a ``1`` prima di avviare lo script:
+Opzione 1: apri direttamente `index.html` nel browser.
 
+Opzione 2 (consigliata per evitare limiti di sicurezza locali):
 ```bash
-PYGAME_HEADLESS=1 python src/main.py
+python -m http.server 8000
 ```
+Poi apri `http://localhost:8000`.
 
-Impostando ``PYGAME_HEADLESS`` a ``0`` si disabilita la modalità headless,
-forzando l'uso del driver video standard. Se la variabile non è definita, la
-modalità headless viene attivata automaticamente solo quando non è rilevato
-alcun display.
-
-## Controlli da tastiera
-- **Freccia su** – accelera
-- **Freccia giù** – frena o retromarcia
-- **Freccia sinistra/destra** – sterza
-- **Esc** – chiude il gioco
-
-## Contributi futuri
-Le proposte di miglioramento sono benvenute. Aprite una issue o una pull request
-per discutere nuove funzionalità, correzioni di bug o idee di design.
+## Controlli
+- `↑` / `W`: accelera
+- `↓` / `S`: frena
+- `←` / `A`: sterza sinistra
+- `→` / `D`: sterza destra
+- `Invio` o `Spazio`: avvia
+- `R`: restart dopo game over
 
 ## Licenza
-Questo progetto è distribuito sotto la licenza MIT. Vedere il file `LICENSE`
-per i dettagli completi.
+MIT (`LICENSE`).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>2D Rally Arcade</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <canvas id="gameCanvas" width="960" height="540" aria-label="2D rally game"></canvas>
+    </main>
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,0 +1,30 @@
+export function createPlayer() {
+  return {
+    laneOffset: 0,
+    speed: 0,
+    maxSpeed: 280,
+    accel: 120,
+    brake: 220,
+    drag: 45,
+    steerPower: 1.5,
+  };
+}
+
+export function createAiCar(trackLength, lane = 0, z = 0, speed = 100) {
+  return {
+    laneOffset: lane,
+    z: ((z % trackLength) + trackLength) % trackLength,
+    speed,
+    widthFactor: 0.32,
+    active: true,
+  };
+}
+
+export function createObstacle(trackLength, lane = 0, z = 0) {
+  return {
+    laneOffset: lane,
+    z: ((z % trackLength) + trackLength) % trackLength,
+    widthFactor: 0.24,
+    active: true,
+  };
+}

--- a/src/game.js
+++ b/src/game.js
@@ -1,0 +1,142 @@
+import { Input } from './input.js';
+import { createAiCar, createObstacle, createPlayer } from './entities.js';
+import { createTrack, segmentIndexAtZ, wrapZ } from './track.js';
+import { renderWorld } from './render.js';
+import { drawHud } from './ui.js';
+
+export class Game {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.input = new Input();
+
+    this.track = createTrack();
+    this.player = createPlayer();
+
+    this.reset();
+  }
+
+  reset() {
+    this.state = 'start';
+    this.distance = 0;
+    this.cameraZ = 0;
+    this.cameraX = 0;
+    this.player.laneOffset = 0;
+    this.player.speed = 0;
+    this.offRoad = false;
+    this.flashTimer = 0;
+
+    this.obstacles = [
+      createObstacle(this.track.length, -0.55, 1000),
+      createObstacle(this.track.length, 0.5, 1750),
+      createObstacle(this.track.length, -0.1, 2450),
+      createObstacle(this.track.length, 0.28, 3250),
+    ];
+
+    this.aiCars = [
+      createAiCar(this.track.length, -0.25, 1300, 105),
+      createAiCar(this.track.length, 0.25, 2100, 120),
+      createAiCar(this.track.length, 0.05, 2900, 96),
+    ];
+  }
+
+  update(dt) {
+    if (this.state === 'start') {
+      if (this.input.pressed('Enter', 'Space')) this.state = 'running';
+      return;
+    }
+
+    if (this.state === 'gameover') {
+      if (this.input.pressed('KeyR', 'Enter', 'Space')) this.reset();
+      return;
+    }
+
+    this.updatePlayer(dt);
+    this.updateCamera(dt);
+    this.updateTraffic(dt);
+    this.handleCollisions();
+  }
+
+  updatePlayer(dt) {
+    const p = this.player;
+    const accelerating = this.input.pressed('ArrowUp', 'KeyW');
+    const braking = this.input.pressed('ArrowDown', 'KeyS');
+    const steerLeft = this.input.pressed('ArrowLeft', 'KeyA');
+    const steerRight = this.input.pressed('ArrowRight', 'KeyD');
+
+    if (accelerating) p.speed += p.accel * dt;
+    if (braking) p.speed -= p.brake * dt;
+
+    p.speed -= p.drag * dt;
+    p.speed = Math.max(0, Math.min(p.maxSpeed, p.speed));
+
+    const seg = this.track.segments[segmentIndexAtZ(this.track, this.cameraZ)];
+    const curveForce = seg.curve * (0.8 + p.speed / p.maxSpeed * 2.1);
+    this.player.laneOffset -= curveForce * dt * 140;
+
+    const steerStrength = p.steerPower * (0.25 + p.speed / p.maxSpeed * 0.95);
+    if (steerLeft) p.laneOffset -= steerStrength * dt;
+    if (steerRight) p.laneOffset += steerStrength * dt;
+
+    this.offRoad = Math.abs(p.laneOffset) > 0.95;
+    if (this.offRoad) {
+      p.speed -= 130 * dt;
+      p.laneOffset = Math.max(-1.25, Math.min(1.25, p.laneOffset));
+    }
+  }
+
+  updateCamera(dt) {
+    this.cameraZ = wrapZ(this.track, this.cameraZ + this.player.speed * dt * 1.2);
+    this.distance += this.player.speed * dt;
+
+    const seg = this.track.segments[segmentIndexAtZ(this.track, this.cameraZ)];
+    this.cameraX += seg.curve * this.player.speed * dt * 0.5;
+    this.cameraX += this.player.laneOffset * 0.018;
+    this.cameraX *= 0.96;
+  }
+
+  updateTraffic(dt) {
+    this.aiCars.forEach((car) => {
+      car.z = wrapZ(this.track, car.z + car.speed * dt);
+      if (Math.random() < 0.004) {
+        car.laneOffset += (Math.random() - 0.5) * 0.15;
+        car.laneOffset = Math.max(-0.75, Math.min(0.75, car.laneOffset));
+      }
+    });
+  }
+
+  handleCollisions() {
+    const hitWindow = 55;
+    let hit = false;
+
+    for (const obstacle of this.obstacles) {
+      const dz = (obstacle.z - this.cameraZ + this.track.length) % this.track.length;
+      if (dz < hitWindow && Math.abs(obstacle.laneOffset - this.player.laneOffset) < 0.24) {
+        obstacle.z = wrapZ(this.track, obstacle.z + 1400 + Math.random() * 800);
+        this.player.speed *= 0.42;
+        hit = true;
+      }
+    }
+
+    for (const ai of this.aiCars) {
+      const dz = (ai.z - this.cameraZ + this.track.length) % this.track.length;
+      if (dz < hitWindow && Math.abs(ai.laneOffset - this.player.laneOffset) < 0.26) {
+        this.player.speed *= 0.68;
+        hit = true;
+      }
+    }
+
+    if (hit && this.player.speed < 22) {
+      this.state = 'gameover';
+    }
+
+    if (this.distance >= 5000) {
+      this.state = 'gameover';
+    }
+  }
+
+  render() {
+    renderWorld(this.ctx, this, this.canvas);
+    drawHud(this.ctx, this, this.canvas);
+  }
+}

--- a/src/input.js
+++ b/src/input.js
@@ -1,0 +1,27 @@
+export class Input {
+  constructor() {
+    this.keys = new Set();
+    window.addEventListener('keydown', (e) => {
+      this.keys.add(e.code);
+      if ([
+        'ArrowLeft',
+        'ArrowRight',
+        'ArrowUp',
+        'ArrowDown',
+        'KeyW',
+        'KeyA',
+        'KeyS',
+        'KeyD',
+        'Space',
+        'Enter',
+      ].includes(e.code)) {
+        e.preventDefault();
+      }
+    });
+    window.addEventListener('keyup', (e) => this.keys.delete(e.code));
+  }
+
+  pressed(...codes) {
+    return codes.some((c) => this.keys.has(c));
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,16 @@
+import { Game } from './game.js';
+
+const canvas = document.getElementById('gameCanvas');
+const game = new Game(canvas);
+
+let lastTime = performance.now();
+
+function loop(now) {
+  const dt = Math.min((now - lastTime) / 1000, 0.05);
+  lastTime = now;
+  game.update(dt);
+  game.render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,140 @@
+import { segmentIndexAtZ, wrapZ } from './track.js';
+
+const FOV = 100;
+const CAMERA_HEIGHT = 900;
+const DRAW_DISTANCE = 220;
+
+function projectPoint(worldX, worldY, worldZ, cameraX, cameraY, cameraZ, width, height, roadHalfWidth) {
+  const dz = worldZ - cameraZ;
+  const dx = worldX - cameraX;
+  const dy = worldY - cameraY;
+  const scale = FOV / dz;
+
+  return {
+    screenX: Math.round((1 + scale * dx) * width * 0.5),
+    screenY: Math.round((1 - scale * dy) * height * 0.5),
+    roadW: Math.round(scale * roadHalfWidth * width * 0.5),
+    scale,
+    dz,
+  };
+}
+
+function drawQuad(ctx, x1, y1, w1, x2, y2, w2, color) {
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(x1 - w1, y1);
+  ctx.lineTo(x2 - w2, y2);
+  ctx.lineTo(x2 + w2, y2);
+  ctx.lineTo(x1 + w1, y1);
+  ctx.closePath();
+  ctx.fill();
+}
+
+export function renderWorld(ctx, game, canvas) {
+  const { width, height } = canvas;
+  const horizon = Math.floor(height * 0.36);
+
+  // Sky + background hills
+  ctx.fillStyle = '#7ec4ff';
+  ctx.fillRect(0, 0, width, horizon);
+  ctx.fillStyle = '#95d86a';
+  ctx.fillRect(0, horizon, width, height - horizon);
+  ctx.fillStyle = 'rgba(60, 110, 55, 0.55)';
+  for (let i = 0; i < 8; i += 1) {
+    const hillX = ((i * 170 - game.distance * 0.05) % (width + 300)) - 150;
+    ctx.beginPath();
+    ctx.ellipse(hillX, horizon + 20, 160, 55, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const { track, cameraZ } = game;
+  let baseIndex = segmentIndexAtZ(track, cameraZ);
+  let x = 0;
+  let dx = 0;
+  let maxY = height;
+
+  for (let n = 0; n < DRAW_DISTANCE; n += 1) {
+    const segIndex = (baseIndex + n) % track.segments.length;
+    const segment = track.segments[segIndex];
+
+    const z1 = wrapZ(track, Math.floor(cameraZ / track.segmentLength) * track.segmentLength + n * track.segmentLength);
+    const z2 = wrapZ(track, z1 + track.segmentLength);
+
+    const p1 = projectPoint(x, 0, z1, game.cameraX, CAMERA_HEIGHT, cameraZ, width, height, track.roadHalfWidth);
+    x += dx;
+    dx += segment.curve;
+    const p2 = projectPoint(x, 0, z2, game.cameraX, CAMERA_HEIGHT, cameraZ, width, height, track.roadHalfWidth);
+
+    if (p1.dz <= 1 || p2.dz <= 1 || p2.screenY >= maxY) continue;
+
+    const grass = segment.colorIndex ? '#4aa14c' : '#3b8f40';
+    const rumble = segment.colorIndex ? '#ffefef' : '#d23131';
+    const road = segment.colorIndex ? '#626262' : '#5a5a5a';
+
+    ctx.fillStyle = grass;
+    ctx.fillRect(0, p2.screenY, width, p1.screenY - p2.screenY);
+
+    drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 1.16, p2.screenX, p2.screenY, p2.roadW * 1.16, rumble);
+    drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW, p2.screenX, p2.screenY, p2.roadW, road);
+
+    if (n % 3 === 0) {
+      drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 0.05, p2.screenX, p2.screenY, p2.roadW * 0.05, '#e6e6e6');
+    }
+
+    renderRoadObjects(ctx, game, segIndex, p2, p1, width);
+    maxY = p2.screenY;
+  }
+
+  renderPlayerCar(ctx, game, width, height);
+}
+
+function renderRoadObjects(ctx, game, segIndex, nearProj, farProj) {
+  const drawObject = (obj, color, heightFactor) => {
+    const t = (obj.z - game.cameraZ + game.track.length) % game.track.length;
+    if (t < 0 || t > DRAW_DISTANCE * game.track.segmentLength) return;
+
+    const scale = nearProj.scale;
+    const x = nearProj.screenX + nearProj.roadW * obj.laneOffset;
+    const h = Math.max(8, nearProj.roadW * heightFactor);
+    const w = Math.max(6, nearProj.roadW * obj.widthFactor);
+
+    ctx.fillStyle = color;
+    ctx.fillRect(x - w / 2, nearProj.screenY - h, w, h);
+    ctx.fillStyle = 'rgba(255,255,255,0.28)';
+    ctx.fillRect(x - (w * 0.25), nearProj.screenY - h + 2, w * 0.5, h * 0.2);
+  };
+
+  game.obstacles.forEach((o) => {
+    if (o.active && Math.floor(o.z / game.track.segmentLength) % game.track.segments.length === segIndex) {
+      drawObject(o, '#8d5a2b', 0.36);
+    }
+  });
+
+  game.aiCars.forEach((c) => {
+    if (c.active && Math.floor(c.z / game.track.segmentLength) % game.track.segments.length === segIndex) {
+      drawObject(c, '#2f4ac7', 0.48);
+    }
+  });
+}
+
+function renderPlayerCar(ctx, game, width, height) {
+  const baseX = width * 0.5 + game.player.laneOffset * width * 0.22;
+  const baseY = height * 0.86;
+  const sway = Math.sin(game.distance * 0.07) * Math.min(6, game.player.speed * 0.03);
+
+  ctx.save();
+  ctx.translate(baseX + sway, baseY);
+
+  ctx.fillStyle = '#17328f';
+  ctx.fillRect(-35, -35, 70, 35);
+  ctx.fillStyle = '#244dd2';
+  ctx.fillRect(-28, -50, 56, 15);
+  ctx.fillStyle = '#f4d35e';
+  ctx.fillRect(-22, -25, 14, 8);
+  ctx.fillRect(8, -25, 14, 8);
+  ctx.fillStyle = '#111';
+  ctx.fillRect(-40, -12, 16, 16);
+  ctx.fillRect(24, -12, 16, 16);
+
+  ctx.restore();
+}

--- a/src/track.js
+++ b/src/track.js
@@ -1,0 +1,42 @@
+const SEGMENT_LENGTH = 30;
+const ROAD_HALF_WIDTH = 1;
+
+function addSegment(segments, curve, count, palette = 0) {
+  for (let i = 0; i < count; i += 1) {
+    segments.push({
+      curve,
+      colorIndex: (segments.length + palette) % 2,
+      sprites: [],
+    });
+  }
+}
+
+export function createTrack() {
+  const segments = [];
+
+  addSegment(segments, 0, 40);
+  addSegment(segments, 0.0012, 60);
+  addSegment(segments, 0, 30);
+  addSegment(segments, -0.0015, 85);
+  addSegment(segments, 0, 20);
+  addSegment(segments, 0.0018, 70);
+  addSegment(segments, -0.001, 50);
+  addSegment(segments, 0, 60);
+
+  return {
+    segments,
+    segmentLength: SEGMENT_LENGTH,
+    roadHalfWidth: ROAD_HALF_WIDTH,
+    length: segments.length * SEGMENT_LENGTH,
+  };
+}
+
+export function segmentIndexAtZ(track, z) {
+  return Math.floor(z / track.segmentLength) % track.segments.length;
+}
+
+export function wrapZ(track, z) {
+  let value = z % track.length;
+  if (value < 0) value += track.length;
+  return value;
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,40 @@
+export function drawHud(ctx, game, canvas) {
+  const speedKmh = Math.round(game.player.speed * 1.45);
+  ctx.fillStyle = 'rgba(5,10,24,0.55)';
+  ctx.fillRect(16, 16, 260, 84);
+
+  ctx.fillStyle = '#dce9ff';
+  ctx.font = '700 20px Segoe UI';
+  ctx.fillText(`Velocità: ${speedKmh} km/h`, 28, 48);
+  ctx.fillText(`Distanza: ${Math.floor(game.distance)} m`, 28, 78);
+
+  if (game.offRoad) {
+    ctx.fillStyle = '#ffbc42';
+    ctx.font = '700 18px Segoe UI';
+    ctx.fillText('FUORI STRADA: trazione ridotta', 300, 48);
+  }
+
+  if (game.state === 'start') {
+    drawOverlay(ctx, canvas, '2D RALLY ARCADE', 'Premi INVIO o SPAZIO per iniziare');
+  } else if (game.state === 'gameover') {
+    drawOverlay(
+      ctx,
+      canvas,
+      'GAME OVER',
+      `Distanza: ${Math.floor(game.distance)} m · Premi R per ripartire`,
+    );
+  }
+}
+
+function drawOverlay(ctx, canvas, title, subtitle) {
+  ctx.fillStyle = 'rgba(3,6,15,0.68)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = '#f5faff';
+  ctx.textAlign = 'center';
+  ctx.font = '800 54px Segoe UI';
+  ctx.fillText(title, canvas.width / 2, canvas.height * 0.43);
+  ctx.font = '700 24px Segoe UI';
+  ctx.fillText(subtitle, canvas.width / 2, canvas.height * 0.55);
+  ctx.textAlign = 'start';
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+:root {
+  color-scheme: dark;
+  --bg: #0a0f18;
+  --panel: #101827;
+  --ink: #e5f4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: radial-gradient(circle at top, #1d3557 0%, var(--bg) 50%, #05070c 100%);
+  font-family: "Segoe UI", Roboto, sans-serif;
+  color: var(--ink);
+}
+
+body {
+  display: grid;
+  place-items: center;
+}
+
+.app-shell {
+  padding: 1rem;
+}
+
+#gameCanvas {
+  width: min(96vw, 960px);
+  height: auto;
+  border: 2px solid #6aa5ff;
+  border-radius: 12px;
+  background: #7ec4ff;
+  box-shadow: 0 20px 40px rgb(0 0 0 / 40%);
+}


### PR DESCRIPTION
### Motivation
- Convert the repository from a Python/Pygame prototype into a browser-first, client-only rally game that runs by opening `index.html` with no backend required. 
- Provide a third-person arcade feel (player car visible from behind, low on screen) using a true pseudo-3D road so depth affects gameplay rather than only background art. 
- Organize the code into small, focused modules to make iterative development and future tuning easy. 

### Description
- Added a browser entrypoint and styles with `index.html` and `style.css` and a minimal loop in `src/main.js` to run the game in a canvas. 
- Implemented a segmented pseudo-3D road renderer in `src/render.js` and track model in `src/track.js` that project segments from far to near, narrow the road toward the horizon, and apply cumulative curve offsets. 
- Implemented core gameplay and state management in `src/game.js`, including player rear-view car rendering, acceleration/braking/steering, off-road penalty, camera movement, traffic/obstacles, simple collision handling, and `start`/`running`/`gameover` flows. 
- Split responsibilities into `src/input.js`, `src/entities.js`, and `src/ui.js` for keyboard handling, entity factories (`createPlayer`, `createAiCar`, `createObstacle`), HUD and overlay rendering, and updated `README.md` with browser launch instructions. 

### Testing
- Performed syntax checks with `node --check` on `src/main.js`, `src/game.js`, `src/render.js`, `src/input.js`, `src/track.js`, `src/entities.js`, and `src/ui.js`, which all succeeded. 
- Confirmed the project opens and runs client-side by launching a static server (recommended `python -m http.server`) and loading `index.html` in a browser as described in `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4aa66a050832c80a3562f3a3ee761)