### PR TITLE
Upgrade 2D Rally from prototype to arcade gameplay experience

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -1,30 +1,40 @@
 export function createPlayer() {
   return {
     laneOffset: 0,
+    laneVelocity: 0,
+    steering: 0,
     speed: 0,
-    maxSpeed: 280,
-    accel: 120,
-    brake: 220,
-    drag: 45,
-    steerPower: 1.5,
+    maxSpeed: 320,
+    accel: 140,
+    brake: 280,
+    drag: 40,
+    steerPower: 1.85,
+    steerResponse: 4.5,
+    steerFriction: 5.2,
+    driftGrip: 0.88,
+    offRoadGrip: 0.72,
   };
 }
 
 export function createAiCar(trackLength, lane = 0, z = 0, speed = 100) {
+  const colors = ['#2f4ac7', '#b93f2d', '#3f9b52', '#6f39b4'];
   return {
     laneOffset: lane,
     z: ((z % trackLength) + trackLength) % trackLength,
     speed,
     widthFactor: 0.32,
+    color: colors[Math.floor(Math.random() * colors.length)],
     active: true,
   };
 }
 
 export function createObstacle(trackLength, lane = 0, z = 0) {
+  const types = ['cone', 'rock', 'hole'];
   return {
     laneOffset: lane,
     z: ((z % trackLength) + trackLength) % trackLength,
     widthFactor: 0.24,
+    type: types[Math.floor(Math.random() * types.length)],
     active: true,
   };
 }

--- a/src/game.js
+++ b/src/game.js
@@ -19,12 +19,21 @@ export class Game {
   reset() {
     this.state = 'start';
     this.distance = 0;
+    this.score = 0;
+    this.avgSpeed = 0;
+    this.runTime = 0;
     this.cameraZ = 0;
     this.cameraX = 0;
     this.player.laneOffset = 0;
+    this.player.laneVelocity = 0;
+    this.player.steering = 0;
     this.player.speed = 0;
     this.offRoad = false;
     this.flashTimer = 0;
+    this.controlLoss = 0;
+    this.shake = 0;
+    this.obstacleSpawnTimer = 0;
+    this.aiSpawnTimer = 0;
 
     this.obstacles = [
       createObstacle(this.track.length, -0.55, 1000),
@@ -54,7 +63,9 @@ export class Game {
     this.updatePlayer(dt);
     this.updateCamera(dt);
     this.updateTraffic(dt);
+    this.updateGameplay(dt);
     this.handleCollisions();
+    this.updateEffects(dt);
   }
 
   updatePlayer(dt) {
@@ -72,16 +83,33 @@ export class Game {
 
     const seg = this.track.segments[segmentIndexAtZ(this.track, this.cameraZ)];
     const curveForce = seg.curve * (0.8 + p.speed / p.maxSpeed * 2.1);
-    this.player.laneOffset -= curveForce * dt * 140;
+    p.laneVelocity -= curveForce * dt * 115;
 
-    const steerStrength = p.steerPower * (0.25 + p.speed / p.maxSpeed * 0.95);
-    if (steerLeft) p.laneOffset -= steerStrength * dt;
-    if (steerRight) p.laneOffset += steerStrength * dt;
+    const steerTarget = (steerRight ? 1 : 0) - (steerLeft ? 1 : 0);
+    p.steering += (steerTarget - p.steering) * Math.min(1, p.steerResponse * dt);
 
+    const speedFactor = 0.3 + p.speed / p.maxSpeed;
+    p.laneVelocity += p.steering * p.steerPower * dt * speedFactor;
+
+    const highSpeed = Math.max(0, (p.speed - p.maxSpeed * 0.62) / p.maxSpeed);
+    const driftFactor = highSpeed * (Math.abs(p.steering) + Math.abs(seg.curve) * 180);
+    p.laneVelocity *= 1 - Math.min(0.23, driftFactor * 0.04);
+    p.laneVelocity *= 1 - Math.min(0.98, p.steerFriction * dt);
+
+    p.laneOffset += p.laneVelocity;
     this.offRoad = Math.abs(p.laneOffset) > 0.95;
+    const grip = this.offRoad ? p.offRoadGrip : p.driftGrip;
+    p.laneVelocity *= grip;
+
     if (this.offRoad) {
-      p.speed -= 130 * dt;
+      p.speed -= 140 * dt;
+      p.laneVelocity += (Math.random() - 0.5) * 0.002;
       p.laneOffset = Math.max(-1.25, Math.min(1.25, p.laneOffset));
+    }
+
+    if (this.controlLoss > 0) {
+      this.controlLoss -= dt;
+      p.laneVelocity += Math.sin(performance.now() * 0.03) * 0.0008;
     }
   }
 
@@ -105,6 +133,45 @@ export class Game {
     });
   }
 
+  updateGameplay(dt) {
+    this.runTime += dt;
+    this.avgSpeed += (this.player.speed - this.avgSpeed) * Math.min(1, dt * 0.7);
+    this.score = Math.floor(this.distance + this.avgSpeed * 4.2);
+
+    this.obstacleSpawnTimer -= dt;
+    if (this.obstacleSpawnTimer <= 0) {
+      this.spawnObstacle();
+      this.obstacleSpawnTimer = 1.2 + Math.random() * 1.5;
+    }
+
+    this.aiSpawnTimer -= dt;
+    if (this.aiSpawnTimer <= 0 && this.aiCars.length < 6) {
+      this.spawnAiCar();
+      this.aiSpawnTimer = 2.8 + Math.random() * 2.2;
+    }
+  }
+
+  updateEffects(dt) {
+    this.flashTimer = Math.max(0, this.flashTimer - dt);
+    this.shake = Math.max(0, this.shake - dt * 2.4);
+  }
+
+  spawnObstacle() {
+    const spawnZ = wrapZ(this.track, this.cameraZ + 900 + Math.random() * 1200);
+    const lanes = [-0.58, -0.35, -0.1, 0.12, 0.37, 0.62];
+    const lane = lanes[Math.floor(Math.random() * lanes.length)];
+    this.obstacles.push(createObstacle(this.track.length, lane, spawnZ));
+    if (this.obstacles.length > 15) this.obstacles.shift();
+  }
+
+  spawnAiCar() {
+    const spawnZ = wrapZ(this.track, this.cameraZ + 1200 + Math.random() * 1700);
+    const lane = -0.5 + Math.random();
+    const speed = 90 + Math.random() * 65;
+    this.aiCars.push(createAiCar(this.track.length, lane, spawnZ, speed));
+    if (this.aiCars.length > 7) this.aiCars.shift();
+  }
+
   handleCollisions() {
     const hitWindow = 55;
     let hit = false;
@@ -113,7 +180,12 @@ export class Game {
       const dz = (obstacle.z - this.cameraZ + this.track.length) % this.track.length;
       if (dz < hitWindow && Math.abs(obstacle.laneOffset - this.player.laneOffset) < 0.24) {
         obstacle.z = wrapZ(this.track, obstacle.z + 1400 + Math.random() * 800);
-        this.player.speed *= 0.42;
+        const impact = obstacle.type === 'hole' ? 0.5 : obstacle.type === 'rock' ? 0.42 : 0.56;
+        this.player.speed *= impact;
+        this.player.laneVelocity += (Math.random() - 0.5) * 0.05;
+        this.controlLoss = Math.max(this.controlLoss, obstacle.type === 'hole' ? 0.85 : 0.7);
+        this.shake = 0.45;
+        this.flashTimer = 0.2;
         hit = true;
       }
     }
@@ -121,7 +193,11 @@ export class Game {
     for (const ai of this.aiCars) {
       const dz = (ai.z - this.cameraZ + this.track.length) % this.track.length;
       if (dz < hitWindow && Math.abs(ai.laneOffset - this.player.laneOffset) < 0.26) {
-        this.player.speed *= 0.68;
+        this.player.speed *= 0.7;
+        this.player.laneVelocity += (Math.random() - 0.5) * 0.04;
+        this.controlLoss = Math.max(this.controlLoss, 0.45);
+        this.shake = 0.3;
+        this.flashTimer = 0.12;
         hit = true;
       }
     }

--- a/src/render.js
+++ b/src/render.js
@@ -32,21 +32,70 @@ function drawQuad(ctx, x1, y1, w1, x2, y2, w2, color) {
 
 export function renderWorld(ctx, game, canvas) {
   const { width, height } = canvas;
-  const horizon = Math.floor(height * 0.36);
+  const horizon = Math.floor(height * 0.35);
+  const shakeX = (Math.random() - 0.5) * 18 * game.shake;
+  const shakeY = (Math.random() - 0.5) * 14 * game.shake;
 
-  // Sky + background hills
-  ctx.fillStyle = '#7ec4ff';
+  ctx.save();
+  ctx.translate(shakeX, shakeY);
+
+  drawBackground(ctx, game, width, height, horizon);
+  drawRoad(ctx, game, width, height);
+  drawSpeedLines(ctx, game, width, height, horizon);
+  renderPlayerCar(ctx, game, width, height);
+
+  if (game.flashTimer > 0) {
+    ctx.fillStyle = `rgba(255,120,95,${Math.min(0.32, game.flashTimer * 1.8)})`;
+    ctx.fillRect(0, 0, width, height);
+  }
+
+  ctx.restore();
+}
+
+function drawBackground(ctx, game, width, height, horizon) {
+  const sky = ctx.createLinearGradient(0, 0, 0, horizon);
+  sky.addColorStop(0, '#9ad8ff');
+  sky.addColorStop(1, '#68b6ff');
+  ctx.fillStyle = sky;
   ctx.fillRect(0, 0, width, horizon);
-  ctx.fillStyle = '#95d86a';
-  ctx.fillRect(0, horizon, width, height - horizon);
-  ctx.fillStyle = 'rgba(60, 110, 55, 0.55)';
-  for (let i = 0; i < 8; i += 1) {
-    const hillX = ((i * 170 - game.distance * 0.05) % (width + 300)) - 150;
+
+  const farMountains = '#5c7ca7';
+  for (let i = 0; i < 6; i += 1) {
+    const x = ((i * 270 - game.distance * 0.03) % (width + 450)) - 220;
+    ctx.fillStyle = farMountains;
     ctx.beginPath();
-    ctx.ellipse(hillX, horizon + 20, 160, 55, 0, 0, Math.PI * 2);
+    ctx.moveTo(x, horizon);
+    ctx.lineTo(x + 130, horizon - 90);
+    ctx.lineTo(x + 300, horizon);
+    ctx.closePath();
     ctx.fill();
   }
 
+  const hillColor = 'rgba(53,109,52,0.75)';
+  for (let i = 0; i < 8; i += 1) {
+    const hillX = ((i * 180 - game.distance * 0.07) % (width + 320)) - 160;
+    ctx.fillStyle = hillColor;
+    ctx.beginPath();
+    ctx.ellipse(hillX, horizon + 20, 170, 55, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const grass = ctx.createLinearGradient(0, horizon, 0, height);
+  grass.addColorStop(0, '#5dbb53');
+  grass.addColorStop(1, '#3e8a37');
+  ctx.fillStyle = grass;
+  ctx.fillRect(0, horizon, width, height - horizon);
+
+  for (let i = 0; i < 200; i += 1) {
+    const x = (i * 131 + Math.floor(game.distance * 0.6)) % width;
+    const y = horizon + ((i * 71) % (height - horizon));
+    const alpha = 0.05 + ((i % 7) / 7) * 0.09;
+    ctx.fillStyle = `rgba(20,65,19,${alpha})`;
+    ctx.fillRect(x, y, 3, 2);
+  }
+}
+
+function drawRoad(ctx, game, width, height) {
   const { track, cameraZ } = game;
   let baseIndex = segmentIndexAtZ(track, cameraZ);
   let x = 0;
@@ -67,74 +116,149 @@ export function renderWorld(ctx, game, canvas) {
 
     if (p1.dz <= 1 || p2.dz <= 1 || p2.screenY >= maxY) continue;
 
-    const grass = segment.colorIndex ? '#4aa14c' : '#3b8f40';
-    const rumble = segment.colorIndex ? '#ffefef' : '#d23131';
-    const road = segment.colorIndex ? '#626262' : '#5a5a5a';
+    const grassA = segment.colorIndex ? '#56ab4d' : '#479742';
+    const grassB = segment.colorIndex ? 'rgba(44,91,35,0.13)' : 'rgba(60,107,47,0.1)';
+    const rumble = segment.colorIndex ? '#f4f4f4' : '#ca3f3f';
+    const road = segment.colorIndex ? '#66696d' : '#575b5f';
 
-    ctx.fillStyle = grass;
+    ctx.fillStyle = grassA;
     ctx.fillRect(0, p2.screenY, width, p1.screenY - p2.screenY);
 
-    drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 1.16, p2.screenX, p2.screenY, p2.roadW * 1.16, rumble);
+    ctx.fillStyle = grassB;
+    for (let s = 0; s < width; s += 48) {
+      ctx.fillRect((s + n * 11) % width, p2.screenY, 24, p1.screenY - p2.screenY);
+    }
+
+    drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 1.17, p2.screenX, p2.screenY, p2.roadW * 1.17, rumble);
     drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW, p2.screenX, p2.screenY, p2.roadW, road);
 
     if (n % 3 === 0) {
-      drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 0.05, p2.screenX, p2.screenY, p2.roadW * 0.05, '#e6e6e6');
+      drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 0.06, p2.screenX, p2.screenY, p2.roadW * 0.06, '#ececec');
     }
 
-    renderRoadObjects(ctx, game, segIndex, p2, p1, width);
+    if (n % 2 === 0) {
+      drawQuad(ctx, p1.screenX, p1.screenY, p1.roadW * 0.9, p2.screenX, p2.screenY, p2.roadW * 0.9, 'rgba(255,255,255,0.03)');
+    }
+
+    renderRoadObjects(ctx, game, segIndex, p2);
     maxY = p2.screenY;
   }
-
-  renderPlayerCar(ctx, game, width, height);
 }
 
-function renderRoadObjects(ctx, game, segIndex, nearProj, farProj) {
-  const drawObject = (obj, color, heightFactor) => {
-    const t = (obj.z - game.cameraZ + game.track.length) % game.track.length;
-    if (t < 0 || t > DRAW_DISTANCE * game.track.segmentLength) return;
-
-    const scale = nearProj.scale;
+function renderRoadObjects(ctx, game, segIndex, nearProj) {
+  const drawObstacle = (obj) => {
     const x = nearProj.screenX + nearProj.roadW * obj.laneOffset;
-    const h = Math.max(8, nearProj.roadW * heightFactor);
-    const w = Math.max(6, nearProj.roadW * obj.widthFactor);
+    const w = Math.max(7, nearProj.roadW * obj.widthFactor);
+    const h = Math.max(10, nearProj.roadW * 0.36);
 
-    ctx.fillStyle = color;
-    ctx.fillRect(x - w / 2, nearProj.screenY - h, w, h);
-    ctx.fillStyle = 'rgba(255,255,255,0.28)';
-    ctx.fillRect(x - (w * 0.25), nearProj.screenY - h + 2, w * 0.5, h * 0.2);
+    if (obj.type === 'cone') {
+      ctx.fillStyle = '#f57c21';
+      ctx.beginPath();
+      ctx.moveTo(x, nearProj.screenY - h);
+      ctx.lineTo(x - w * 0.45, nearProj.screenY);
+      ctx.lineTo(x + w * 0.45, nearProj.screenY);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = '#fff5d6';
+      ctx.fillRect(x - w * 0.15, nearProj.screenY - h * 0.5, w * 0.3, h * 0.12);
+    } else if (obj.type === 'hole') {
+      ctx.fillStyle = 'rgba(22,19,19,0.82)';
+      ctx.beginPath();
+      ctx.ellipse(x, nearProj.screenY - 2, w * 0.55, h * 0.2, 0, 0, Math.PI * 2);
+      ctx.fill();
+    } else {
+      ctx.fillStyle = '#705135';
+      ctx.beginPath();
+      ctx.ellipse(x, nearProj.screenY - h * 0.35, w * 0.5, h * 0.35, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = '#917258';
+      ctx.fillRect(x - w * 0.24, nearProj.screenY - h * 0.55, w * 0.48, h * 0.2);
+    }
+  };
+
+  const drawAiCar = (car) => {
+    const x = nearProj.screenX + nearProj.roadW * car.laneOffset;
+    const w = Math.max(9, nearProj.roadW * car.widthFactor);
+    const h = Math.max(13, nearProj.roadW * 0.55);
+
+    ctx.fillStyle = car.color;
+    ctx.fillRect(x - w * 0.5, nearProj.screenY - h, w, h * 0.72);
+    ctx.fillStyle = '#99b7ff';
+    ctx.fillRect(x - w * 0.28, nearProj.screenY - h * 0.9, w * 0.56, h * 0.2);
+    ctx.fillStyle = '#0e0f12';
+    ctx.fillRect(x - w * 0.52, nearProj.screenY - h * 0.2, w * 0.22, h * 0.2);
+    ctx.fillRect(x + w * 0.3, nearProj.screenY - h * 0.2, w * 0.22, h * 0.2);
   };
 
   game.obstacles.forEach((o) => {
     if (o.active && Math.floor(o.z / game.track.segmentLength) % game.track.segments.length === segIndex) {
-      drawObject(o, '#8d5a2b', 0.36);
+      drawObstacle(o);
     }
   });
 
   game.aiCars.forEach((c) => {
     if (c.active && Math.floor(c.z / game.track.segmentLength) % game.track.segments.length === segIndex) {
-      drawObject(c, '#2f4ac7', 0.48);
+      drawAiCar(c);
     }
   });
+}
+
+function drawSpeedLines(ctx, game, width, height, horizon) {
+  const amount = Math.floor(game.player.speed / 18);
+  if (amount < 3) return;
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.16)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 0; i < amount; i += 1) {
+    const x = (i * 53 + game.distance * 4.2) % width;
+    const y = horizon + ((i * 29) % (height - horizon));
+    ctx.moveTo(x, y);
+    ctx.lineTo(x, y + 8 + amount * 0.15);
+  }
+  ctx.stroke();
 }
 
 function renderPlayerCar(ctx, game, width, height) {
   const baseX = width * 0.5 + game.player.laneOffset * width * 0.22;
   const baseY = height * 0.86;
-  const sway = Math.sin(game.distance * 0.07) * Math.min(6, game.player.speed * 0.03);
+  const wobble = Math.sin(game.distance * 0.08) * Math.min(8, game.player.speed * 0.035);
+  const tilt = -game.player.steering * 0.12;
+  const wheelSpin = game.distance * 0.18;
 
   ctx.save();
-  ctx.translate(baseX + sway, baseY);
+  ctx.translate(baseX + wobble, baseY);
+  ctx.rotate(tilt);
+
+  ctx.fillStyle = 'rgba(0,0,0,0.24)';
+  ctx.beginPath();
+  ctx.ellipse(0, -1, 48, 12, 0, 0, Math.PI * 2);
+  ctx.fill();
 
   ctx.fillStyle = '#17328f';
-  ctx.fillRect(-35, -35, 70, 35);
-  ctx.fillStyle = '#244dd2';
-  ctx.fillRect(-28, -50, 56, 15);
+  ctx.fillRect(-36, -36, 72, 36);
+  ctx.fillStyle = '#2f5bf0';
+  ctx.fillRect(-30, -51, 60, 18);
+  ctx.fillStyle = '#9fd3ff';
+  ctx.fillRect(-20, -48, 40, 11);
+
   ctx.fillStyle = '#f4d35e';
-  ctx.fillRect(-22, -25, 14, 8);
-  ctx.fillRect(8, -25, 14, 8);
-  ctx.fillStyle = '#111';
-  ctx.fillRect(-40, -12, 16, 16);
-  ctx.fillRect(24, -12, 16, 16);
+  ctx.fillRect(-23, -25, 15, 8);
+  ctx.fillRect(8, -25, 15, 8);
+
+  drawWheel(ctx, -39, -12, wheelSpin);
+  drawWheel(ctx, 25, -12, wheelSpin);
 
   ctx.restore();
+}
+
+function drawWheel(ctx, x, y, spin) {
+  ctx.fillStyle = '#121316';
+  ctx.fillRect(x, y, 16, 17);
+  ctx.strokeStyle = '#6b6e77';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(x + 8, y + 2);
+  ctx.lineTo(x + 8 + Math.sin(spin) * 4, y + 15);
+  ctx.stroke();
 }

--- a/src/track.js
+++ b/src/track.js
@@ -14,14 +14,18 @@ function addSegment(segments, curve, count, palette = 0) {
 export function createTrack() {
   const segments = [];
 
-  addSegment(segments, 0, 40);
-  addSegment(segments, 0.0012, 60);
   addSegment(segments, 0, 30);
-  addSegment(segments, -0.0015, 85);
+  addSegment(segments, 0.0009, 40);
+  addSegment(segments, 0.0015, 30);
+  addSegment(segments, 0.0005, 25);
+  addSegment(segments, 0, 15);
+  addSegment(segments, -0.0012, 55);
+  addSegment(segments, -0.0018, 25);
   addSegment(segments, 0, 20);
-  addSegment(segments, 0.0018, 70);
-  addSegment(segments, -0.001, 50);
-  addSegment(segments, 0, 60);
+  addSegment(segments, 0.0013, 45);
+  addSegment(segments, -0.001, 35);
+  addSegment(segments, 0.0007, 30);
+  addSegment(segments, 0, 25);
 
   return {
     segments,

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,12 +1,22 @@
 export function drawHud(ctx, game, canvas) {
   const speedKmh = Math.round(game.player.speed * 1.45);
+  const avgKmh = Math.round(game.avgSpeed * 1.45);
   ctx.fillStyle = 'rgba(5,10,24,0.55)';
-  ctx.fillRect(16, 16, 260, 84);
+  ctx.fillRect(16, 16, 290, 124);
 
   ctx.fillStyle = '#dce9ff';
   ctx.font = '700 20px Segoe UI';
   ctx.fillText(`Velocità: ${speedKmh} km/h`, 28, 48);
   ctx.fillText(`Distanza: ${Math.floor(game.distance)} m`, 28, 78);
+  ctx.fillText(`Media: ${avgKmh} km/h`, 28, 108);
+
+  ctx.fillStyle = 'rgba(5,10,24,0.55)';
+  ctx.fillRect(canvas.width - 220, 16, 200, 74);
+  ctx.fillStyle = '#f8fbff';
+  ctx.font = '800 18px Segoe UI';
+  ctx.fillText('Punteggio', canvas.width - 198, 44);
+  ctx.font = '800 28px Segoe UI';
+  ctx.fillText(`${game.score}`, canvas.width - 198, 78);
 
   if (game.offRoad) {
     ctx.fillStyle = '#ffbc42';
@@ -15,13 +25,13 @@ export function drawHud(ctx, game, canvas) {
   }
 
   if (game.state === 'start') {
-    drawOverlay(ctx, canvas, '2D RALLY ARCADE', 'Premi INVIO o SPAZIO per iniziare');
+    drawOverlay(ctx, canvas, '2D RALLY ARCADE', 'Premi SPAZIO per iniziare');
   } else if (game.state === 'gameover') {
     drawOverlay(
       ctx,
       canvas,
       'GAME OVER',
-      `Distanza: ${Math.floor(game.distance)} m · Premi R per ripartire`,
+      `Score: ${game.score} · Distanza: ${Math.floor(game.distance)} m · Premi R`,
     );
   }
 }


### PR DESCRIPTION
### Motivation
- The project was a minimal pseudo‑3D demo with flat visuals, weak movement feel, and little gameplay depth, so the goal was to evolve it into a compact arcade experience while keeping the architecture simple.
- Deliverables targeted stronger driving physics, a moving/parallax world, obstacles/traffic with meaningful collisions, and a clearer HUD/start/game‑over flow to make the game feel satisfying. 

### Description
- Implemented richer player physics and handling by adding `laneVelocity`, `steering`, grip/drift/off‑road parameters and tuning acceleration/brake/drag in `src/entities.js` and updated steering/drift behavior and temporary control loss in `src/game.js`. 
- Added game systems in `src/game.js`: dynamic obstacle and AI spawning (`spawnObstacle`, `spawnAiCar`), scoring based on distance + average speed, `avgSpeed`/`score` tracking, impact flash, camera shake and control loss handling, and expanded collision effects per obstacle type. 
- Rewrote and enhanced rendering in `src/render.js` to provide parallax sky/mountains/hills, richer grass and road textures, dashed center lane/rumble strips, speed lines for motion, and a more detailed player car with wheel animation and steering tilt; obstacles and AI cars are now drawn by type/color. 
- Expanded track composition (`src/track.js`) to create more varied light curves, and improved HUD/overlays in `src/ui.js` to show speed, average speed, distance and score and to clarify start/game‑over messaging. 
- Files modified: `src/entities.js`, `src/game.js`, `src/render.js`, `src/track.js`, `src/ui.js` with no external assets added (all canvas/shape based). 

### Testing
- Performed static syntax checks using `node --check` on updated modules: `src/game.js`, `src/render.js`, `src/ui.js`, `src/entities.js`, and `src/track.js`. The checks completed without errors. 
- The changes were smoke‑validated in the app loop (game update/render integration) during development; no automated runtime test failures were reported by the static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4acf2e6f4832ca3325011c94db3bb)