### PR TITLE
Fix road rendering disappearing due to wrapped segment depth

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,4 @@
-import { segmentIndexAtZ, wrapZ } from './track.js';
+import { segmentIndexAtZ } from './track.js';
 
 const FOV = 100;
 const CAMERA_HEIGHT = 900;
@@ -101,6 +101,7 @@ function drawRoad(ctx, game, width, height) {
   const { track, cameraZ } = game;
   const horizon = Math.floor(height * 0.35);
   const baseIndex = segmentIndexAtZ(track, cameraZ);
+  const baseSegmentZ = Math.floor(cameraZ / track.segmentLength) * track.segmentLength;
   const roadSpan = Math.max(1, height - horizon);
   const dashedOffset = Math.floor(game.distance * 0.08);
 
@@ -112,8 +113,8 @@ function drawRoad(ctx, game, width, height) {
     const segIndex = (baseIndex + n) % track.segments.length;
     const segment = track.segments[segIndex];
 
-    const z1 = wrapZ(track, Math.floor(cameraZ / track.segmentLength) * track.segmentLength + n * track.segmentLength);
-    const z2 = wrapZ(track, z1 + track.segmentLength);
+    const z1 = baseSegmentZ + n * track.segmentLength;
+    const z2 = z1 + track.segmentLength;
 
     const p1 = projectPoint(x, 0, z1, game.cameraX, CAMERA_HEIGHT, cameraZ, width, height, track.roadHalfWidth);
     x += dx;


### PR DESCRIPTION
### Motivation
- Prevent the road from intermittently disappearing when projected segment Z values were wrapped back to the start of the track and produced near-zero/negative depth (`dz`).
- Ensure segments in front of the camera are projected using a continuous forward Z so `projectPoint` receives a positive depth.

### Description
- Remove `wrapZ` import from `src/render.js` and stop wrapping per-segment Z when building projection slices.
- Introduce `baseSegmentZ = Math.floor(cameraZ / track.segmentLength) * track.segmentLength` and compute `z1 = baseSegmentZ + n * track.segmentLength` and `z2 = z1 + track.segmentLength` for each projected slice.
- Keep segment indexing and styling logic unchanged (segment index still computed with modulo), only the world Z used for projection is continuous to preserve `dz`.

### Testing
- Ran `node --check src/render.js && node --check src/game.js`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4bb3d9118832c9c7c8b5555be7885)