### PR TITLE
Fix road rendering order to restore continuous carriageway

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -113,10 +113,8 @@ function drawRoad(ctx, game, width, height) {
     const segIndex = (baseIndex + n) % track.segments.length;
     const segment = track.segments[segIndex];
 
-    const z1 = baseSegmentZ + n * track.segmentLength;
-    const z2 = z1 + track.segmentLength;
+    const z2 = baseSegmentZ + (n + 1) * track.segmentLength;
 
-    const p1 = projectPoint(x, 0, z1, game.cameraX, CAMERA_HEIGHT, cameraZ, width, height, track.roadHalfWidth);
     x += dx;
     dx += segment.curve;
     const p2 = projectPoint(x, 0, z2, game.cameraX, CAMERA_HEIGHT, cameraZ, width, height, track.roadHalfWidth);
@@ -139,9 +137,9 @@ function drawRoad(ctx, game, width, height) {
   }
 
   let lastY = height + 2;
-  for (let i = 0; i < projected.length - 1; i += 1) {
-    const far = projected[i];
-    const near = projected[i + 1];
+  for (let i = projected.length - 1; i > 0; i -= 1) {
+    const near = projected[i];
+    const far = projected[i - 1];
     const topY = Math.max(horizon, far.y);
     const bottomY = Math.min(lastY, near.y);
 


### PR DESCRIPTION
### Motivation
- Road trapezoids were being drawn in an order that produced visible gaps and incoherent perspective at the horizon. 
- The previous code computed an unused projection (`p1`) and kept an ambiguous z computation that could lead to stale geometry state. 
- The goal is to draw road segments from far → near so quads overlap correctly and the carriageway appears continuous. 

### Description
- Iterate the `projected` array from far-to-near by changing the loop to `for (let i = projected.length - 1; i > 0; i -= 1)` and pair `near = projected[i]` with `far = projected[i - 1]` in `src/render.js`. 
- Remove the unused `p1` projection and simplify z computation by using `z2 = baseSegmentZ + (n + 1) * track.segmentLength` when building `projected`. 
- Keep the rest of the road-drawing logic intact so trapezoid top/bottom coherence and road object rendering remain consistent. 

### Testing
- Ran `node --check src/render.js` which completed successfully. 
- Ran `node --check src/main.js` which completed successfully. 
- Ran `python -m py_compile src/main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cff24da4832c9a945a144a79f852)