### PR TITLE
Fix camera height so road renders visibly

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,7 +1,9 @@
 import { segmentIndexAtZ } from './track.js';
 
 const FOV = 100;
-const CAMERA_HEIGHT = 900;
+// World Y units are in "road widths", so the camera height must stay low.
+// A very large value flattens every segment to the screen bottom and the road disappears.
+const CAMERA_HEIGHT = 1.15;
 const DRAW_DISTANCE = 220;
 const ROAD_BOTTOM_HALF_WIDTH_RATIO = 0.34;
 const ROAD_TOP_HALF_WIDTH_RATIO = 0.085;


### PR DESCRIPTION
### Motivation
- The road could disappear because `CAMERA_HEIGHT` was using a pixel-scale value (`900`) instead of world-space units, which collapsed projected segment Y values to the bottom of the canvas.

### Description
- Change `CAMERA_HEIGHT` from `900` to `1.15` in `src/render.js` and add a comment clarifying that camera Y is in world units to avoid flattening the projected road.

### Testing
- Ran `for f in src/*.js; do node --check "$f"; done` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4d26745c4832cb93f2f5bd1a2f662)