### PR TITLE
Add mobile on-screen touch controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Poi apri `http://localhost:8000`.
 - `→` / `D`: sterza destra
 - `Invio` o `Spazio`: avvia
 - `R`: restart dopo game over
+- Mobile: pulsanti touch a schermo (sterzo, accelera, frena, start/restart)
 
 ## Licenza
 MIT (`LICENSE`).

--- a/index.html
+++ b/index.html
@@ -9,6 +9,20 @@
   <body>
     <main class="app-shell">
       <canvas id="gameCanvas" width="960" height="540" aria-label="2D rally game"></canvas>
+
+      <section id="mobileControls" class="mobile-controls" aria-label="Controlli mobile">
+        <div class="mobile-controls__dpad">
+          <button class="mobile-btn" data-code="ArrowLeft" aria-label="Sterza sinistra">◀</button>
+          <button class="mobile-btn" data-code="ArrowRight" aria-label="Sterza destra">▶</button>
+        </div>
+        <div class="mobile-controls__actions">
+          <button class="mobile-btn mobile-btn--primary" data-code="ArrowUp" aria-label="Accelera">▲</button>
+          <button class="mobile-btn" data-code="ArrowDown" aria-label="Frena">▼</button>
+          <button class="mobile-btn mobile-btn--start" data-code="Space" aria-label="Avvia o restart">
+            START
+          </button>
+        </div>
+      </section>
     </main>
     <script type="module" src="src/main.js"></script>
   </body>

--- a/src/input.js
+++ b/src/input.js
@@ -1,6 +1,8 @@
 export class Input {
   constructor() {
     this.keys = new Set();
+    this.virtualKeys = new Set();
+
     window.addEventListener('keydown', (e) => {
       this.keys.add(e.code);
       if ([
@@ -18,10 +20,41 @@ export class Input {
         e.preventDefault();
       }
     });
+
     window.addEventListener('keyup', (e) => this.keys.delete(e.code));
+
+    this.bindMobileControls();
+  }
+
+  bindMobileControls() {
+    const controls = document.getElementById('mobileControls');
+    if (!controls) return;
+
+    const holdButtons = controls.querySelectorAll('[data-code]');
+    holdButtons.forEach((button) => {
+      const code = button.dataset.code;
+      if (!code) return;
+
+      const press = (e) => {
+        e.preventDefault();
+        this.virtualKeys.add(code);
+        button.classList.add('is-pressed');
+      };
+
+      const release = (e) => {
+        e.preventDefault();
+        this.virtualKeys.delete(code);
+        button.classList.remove('is-pressed');
+      };
+
+      button.addEventListener('pointerdown', press);
+      button.addEventListener('pointerup', release);
+      button.addEventListener('pointerleave', release);
+      button.addEventListener('pointercancel', release);
+    });
   }
 
   pressed(...codes) {
-    return codes.some((c) => this.keys.has(c));
+    return codes.some((c) => this.keys.has(c) || this.virtualKeys.has(c));
   }
 }

--- a/style.css
+++ b/style.css
@@ -35,3 +35,54 @@ body {
   background: #7ec4ff;
   box-shadow: 0 20px 40px rgb(0 0 0 / 40%);
 }
+
+.mobile-controls {
+  display: none;
+}
+
+@media (max-width: 1024px), (hover: none) and (pointer: coarse) {
+  .mobile-controls {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 0.85rem;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+  }
+
+  .mobile-controls__dpad,
+  .mobile-controls__actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .mobile-btn {
+    min-width: 62px;
+    min-height: 62px;
+    border: 2px solid #6aa5ff;
+    border-radius: 14px;
+    background: rgba(16, 24, 39, 0.8);
+    color: #eaf3ff;
+    font-weight: 800;
+    font-size: 1.2rem;
+    box-shadow: 0 10px 18px rgb(0 0 0 / 35%);
+  }
+
+  .mobile-btn.is-pressed {
+    transform: translateY(1px) scale(0.97);
+    background: rgba(106, 165, 255, 0.35);
+    border-color: #9ec4ff;
+  }
+
+  .mobile-btn--primary {
+    background: rgba(33, 94, 180, 0.9);
+  }
+
+  .mobile-btn--start {
+    min-width: 88px;
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide playable touch controls on mobile/touch devices so the game can be used without a physical keyboard.
- Keep existing keyboard controls intact while exposing the same input semantics to on-screen buttons.

### Description
- Add a `#mobileControls` section to `index.html` with buttons for left/right steering, accelerate, brake and start/restart using `data-code` attributes that mirror keyboard codes.
- Extend `Input` (`src/input.js`) with a `virtualKeys` set and `bindMobileControls()` that maps pointer events (`pointerdown`/`pointerup`/etc.) to virtual key presses and adds a pressed visual state; `pressed(...)` now checks both physical and virtual keys.
- Add responsive CSS in `style.css` to show the mobile controls on small or coarse-pointer devices and provide visual feedback for pressed buttons.
- Document mobile controls in `README.md` under the `## Controlli` section.

### Testing
- Ran syntax/type checks with `node --check src/input.js` and the check succeeded.
- Ran syntax/type checks with `node --check src/main.js` and the check succeeded.
- Ran syntax/type checks with `node --check src/game.js` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68d1f4434832ca82ae262dfc4ef1c)