### PR TITLE
Fix car disappearing during acceleration

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -111,7 +111,8 @@ export class Game {
     p.laneVelocity *= 1 - Math.min(0.28, driftFactor * 0.05);
     p.laneVelocity *= 1 - Math.min(0.98, p.steerFriction * dt);
 
-    p.laneOffset += p.laneVelocity;
+    // Integrate lateral movement with delta-time so lane drift stays frame-rate independent.
+    p.laneOffset += p.laneVelocity * dt;
     this.offRoad = Math.abs(p.laneOffset) > 0.95;
     const grip = this.offRoad ? p.offRoadGrip : p.driftGrip;
     p.laneVelocity *= grip;
@@ -121,6 +122,9 @@ export class Game {
       p.laneVelocity += (Math.random() - 0.5) * 0.003;
       p.laneOffset = Math.max(-1.35, Math.min(1.35, p.laneOffset));
     }
+
+    // Keep the car recoverable even after strong drifts/impacts.
+    p.laneOffset = Math.max(-1.35, Math.min(1.35, p.laneOffset));
 
     if (this.controlLoss > 0) {
       this.controlLoss -= dt;


### PR DESCRIPTION
### Motivation
- Fix a bug where the player car would drift off-screen and effectively “disappear” after a few seconds of accelerating because lateral movement was applied per-frame without scaling by delta time.

### Description
- In `src/game.js` integrate lateral movement using `dt` by changing `p.laneOffset += p.laneVelocity` to `p.laneOffset += p.laneVelocity * dt` so lateral motion is frame-rate independent.
- Add a persistent safety clamp `p.laneOffset = Math.max(-1.35, Math.min(1.35, p.laneOffset))` applied each frame to keep the car recoverable after strong drifts or impacts.

### Testing
- Ran `node --check src/game.js` which completed successfully.
- Ran `node --check src/main.js` and `node --check src/render.js` and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9154a796c832ca16e6b433484a3a9)