### PR TITLE
Prevent gh-pages race by adding shared concurrency to Pages workflows

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
       - name: Extract preview name
         id: preview
         run: |
-          BRANCH="${{ github.head_ref }}"
+          BRANCH="${{ github.event.pull_request.head.ref }}"
           PREVIEW_NAME="${BRANCH##*/}"
           PREVIEW_NAME=$(echo "$PREVIEW_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
           echo "name=$PREVIEW_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
         id: preview
         run: |
           # Use the branch name after the last slash, sanitized
-          BRANCH="${{ github.head_ref }}"
+          BRANCH="${{ github.event.pull_request.head.ref }}"
           PREVIEW_NAME="${BRANCH##*/}"
           PREVIEW_NAME=$(echo "$PREVIEW_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
           echo "name=$PREVIEW_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation
- When a PR is merged the preview cleanup (on `pull_request.closed`) and main deploy (on `push` to `main`) can run concurrently and race when pushing to the `gh-pages` branch, which can leave the preview directory behind or make cleanup appear flaky.

### Description
- Add a shared `concurrency` group `gh-pages-deploy` with `cancel-in-progress: false` to the GitHub Pages workflows to serialize pushes to `gh-pages`.
- Use `github.event.pull_request.head.ref` instead of `github.head_ref` in the PR deploy and cleanup workflows so preview-name extraction reads the PR payload explicitly.
- Files changed: `.github/workflows/preview-deploy.yml`, `.github/workflows/preview-cleanup.yml`, `.github/workflows/deploy-main.yml`.

### Testing
- Ran `git diff --check` which returned no problems for the edited workflow files.
- Attempted YAML validation with `python` and `yaml.safe_load`, but the run failed due to the environment missing the `PyYAML` module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91666b078832cbbd8f5e644a51ea5)